### PR TITLE
fix(bug): fix issue with block-storage-provisioner

### DIFF
--- a/block-storage-provisioner/Dockerfile
+++ b/block-storage-provisioner/Dockerfile
@@ -1,5 +1,4 @@
-FROM ubuntu:18.10
-
+FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -y python3.6 python3-pip git jq apt-transport-https curl wget gzip tar
 RUN pip3 install SoftLayer pyyaml 

--- a/block-storage-provisioner/px_iks_utils.py
+++ b/block-storage-provisioner/px_iks_utils.py
@@ -33,12 +33,12 @@ class IKS_clusters:
         self._token = IAMToken
 
         self._hdrs = {'Content-Type': 'application/json',
-                      'Authorization': self._token}
+                      'Authorization': self._token, 'User-Agent': 'mkpvyaml.py'}
 
         if not region:
             try:
                 request = urllib.request.Request(
-                    url="https://containers.bluemix.net/v1/regions",
+                    url="https://containers.cloud.ibm.com/v1/regions",
                     headers=self._hdrs)
                 contents = json.load(urllib.request.urlopen(request))
             except EnvironmentError:
@@ -52,16 +52,16 @@ class IKS_clusters:
 
         for r in self._region:
             self._hdrs = {'Content-Type': 'application/json',
-                          'X-Region': r, 'Authorization': self._token}
+                          'X-Region': r, 'User-Agent': 'mkpvyaml.py', 'Authorization': self._token}
             try:
                 if not cluster:
                     request = urllib.request.Request(
-                        url="https://containers.bluemix.net/v1/clusters",
+                        url="https://containers.cloud.ibm.com/v1/clusters",
                         headers=self._hdrs)
                     cl_contents = json.load(urllib.request.urlopen(request))
                 else:
                     request = urllib.request.Request(
-                        url="https://containers.bluemix.net/v1/clusters/" +
+                        url="https://containers.cloud.ibm.com/v1/clusters/" +
                         cluster,
                         headers=self._hdrs)
                     cl_contents = [json.load(urllib.request.urlopen(request))]
@@ -72,7 +72,7 @@ class IKS_clusters:
                     cls['workers'] = []
                     try:
                         request = urllib.request.Request(
-                            url="https://containers.bluemix.net/v1/clusters/" +
+                            url="https://containers.cloud.ibm.com/v1/clusters/" +
                             cl['name'] + "/workers", headers=self._hdrs)
                         w_contents = json.load(urllib.request.urlopen(request))
                     except EnvironmentError:


### PR DESCRIPTION
This PR fixes the issue in block storage provisioning using the block-storage provisioner
that was happening because of the change in IBM cloud containers endpoint from
`https://containers.bluemix.net` to `https://containers.cloud.ibm.com`.

Signed-off-by: “Sagar-Kumar3” <Sagar.Kumar3@ibm.com>