### PR TITLE
changes to order of pre-req testing, checking for plugins, etc

### DIFF
--- a/px-utils/px_vpc_upgrade/README.md
+++ b/px-utils/px_vpc_upgrade/README.md
@@ -11,7 +11,7 @@
   Once the cluster config is set run the scirpt  
 
   ```
-  sudo ./px_vpc_upgrade.sh  mycluster  replace/upgrade  worker/worker-pool (workerid1 workerid2) / (worker-pool-id1 worker-pool-id2) ....
+  sudo ./px_vpc_upgrade.sh mycluster replace worker/worker-pool (workerid1 workerid2) / (worker-pool-id1 worker-pool-id2) ....
   ```
 
 - If the worker ids not provided then all the workers in the cluster will be replaced/upgraded 

--- a/px-utils/px_vpc_upgrade/README.md
+++ b/px-utils/px_vpc_upgrade/README.md
@@ -11,7 +11,7 @@
   Once the cluster config is set run the scirpt  
 
   ```
-  sudo ./vpc_upgrade_util.sh  mycluster  replace/upgrade  worker/worker-pool (workerid1 workerid2) / (worker-pool-id1 worker-pool-id2) ....
+  sudo ./px_vpc_upgrade.sh  mycluster  replace/upgrade  worker/worker-pool (workerid1 workerid2) / (worker-pool-id1 worker-pool-id2) ....
   ```
 
 - If the worker ids not provided then all the workers in the cluster will be replaced/upgraded 

--- a/px-utils/px_vpc_upgrade/px_vpc_upgrade.sh
+++ b/px-utils/px_vpc_upgrade/px_vpc_upgrade.sh
@@ -279,16 +279,16 @@ do
    echo "worker id : $id"
    zone=$(ic ks worker get --worker $id --cluster $CLUSTER --json | jq -r .location)
    volid_perworker=$(ic is vols --json | jq -r --arg WORKER_NAME "$id" '.[]|select(.volume_attachments[] .instance.name==$WORKER_NAME) | .id')
-   echo "volid :${volid_perworker[*]} is attached to the worker :${id}"
+   echo "volid : ${volid_perworker[*]} is attached to the worker :${id}"
    vol_ids[volindex]=${volid_perworker[@]}
    ((volindex++))
   sleep 20
   px_label_check=$(kubectl get nodes -l px/enabled=false -o json |  grep  $id)
-  ic cs worker $command_name  --cluster  $CLUSTER --worker $id
+
+  IC_WORKER_ACTION_RESPONSE=$(ic cs worker $command_name  --cluster  $CLUSTER --worker $id 2>&1 > /dev/tty)
+  echo $IC_WORKER_ACTION_RESPONSE
+  [[ "$IC_WORKER_ACTION_RESPONSE" ]] && { echo "Action canceled. Exiting script "; exit; }
+
   echo "The worker is being deleted, waiting for the new worker ............"
   executereplaceorupgrade 
 done
-
-
-         
-


### PR DESCRIPTION
after testing this utility I was able to make some changes to the pre-req checks to improve usability.  I also changed the order of the existing checks to come before the worker id query.  Without the vpc-infra or container service plugins you cannot list the storage volumes and act on Kube.  These were not being checked for in the original script. 

this script claims to "upgrade" worker nodes - "upgrade" is not a ks workers command - update and replace exists, but no upgrade.